### PR TITLE
fix: move module to peer deps to avoid duplicates

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,25 +36,29 @@
     "url": "https://github.com/edx/frontend-lib-special-exams/issues"
   },
   "dependencies": {
-    "@edx/frontend-platform": "1.8.4",
-    "@edx/paragon": "13.17.0",
     "@fortawesome/fontawesome-svg-core": "1.2.34",
     "@fortawesome/free-brands-svg-icons": "5.11.2",
     "@fortawesome/free-regular-svg-icons": "5.11.2",
     "@fortawesome/free-solid-svg-icons": "5.11.2",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@reduxjs/toolkit": "^1.5.1",
-    "babel-polyfill": "6.26.0",
+    "babel-polyfill": "6.26.0"
+  },
+  "peerDependencies": {
+    "@edx/frontend-platform": "1.8.4",
+    "@edx/paragon": "13.17.0",
     "prop-types": "15.7.2",
     "react": "16.12.0",
     "react-dom": "16.12.0",
     "react-redux": "7.1.3",
     "react-router": "5.1.2",
     "react-router-dom": "5.1.2",
-    "redux": "4.0.5"
+    "redux": "4.0.5",
+    "@reduxjs/toolkit": "^1.5.1"
   },
   "devDependencies": {
     "@edx/frontend-build": "^5.6.11",
+    "@edx/frontend-platform": "1.8.4",
+    "@edx/paragon": "13.17.0",
     "@testing-library/jest-dom": "5.10.1",
     "@testing-library/react": "10.3.0",
     "axios-mock-adapter": "1.18.2",
@@ -63,6 +67,14 @@
     "glob": "7.1.6",
     "husky": "3.1.0",
     "jest": "24.9.0",
+    "prop-types": "15.7.2",
+    "react": "16.12.0",
+    "react-dom": "16.12.0",
+    "react-redux": "7.1.3",
+    "react-router": "5.1.2",
+    "react-router-dom": "5.1.2",
+    "redux": "4.0.5",
+    "@reduxjs/toolkit": "^1.5.1",
     "reactifex": "1.1.1"
   }
 }


### PR DESCRIPTION
These modules need to be peer dependencies so this library doesn't use a second instance of them and instead relies on the parent app. This is working right now only because locally the package folder is inside the learning MFE but if you build this project separately or have a different path you end up with multiple versions of frontend-platform and react.

Also allows us to import this using `import { SequenceExamWrapper } from '@edx/frontend-lib-special-exams'` and rely on the `module.config.js` file to define the path.

more info on using module config: https://github.com/edx/frontend-build#local-module-configuration-for-webpack