### PR TITLE
[BD-26][EDUCATOR-5798] fix: don't do polling when exam is in 'ready_to_submit' status

### DIFF
--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -61,6 +61,15 @@ export function startExam() {
 export function pollAttempt(url) {
   return async (dispatch, getState) => {
     const currentAttempt = getState().examState.activeAttempt;
+
+    // If the learner is in a state where they've finished the exam
+    // and the attempt can be submitted (i.e. they are "ready_to_submit"),
+    // don't ping the proctoring app (which action could move
+    // the attempt into an error state).
+    if (currentAttempt && currentAttempt.attempt_status === ExamStatus.READY_TO_SUBMIT) {
+      return;
+    }
+
     const data = await pollExamAttempt(url).catch(
       err => logError(err),
     );

--- a/src/timer/TimerProvider.jsx
+++ b/src/timer/TimerProvider.jsx
@@ -7,7 +7,6 @@ import {
   TIMER_IS_LOW,
   TIMER_LIMIT_REACHED,
 } from './events';
-import { ExamStatus } from '../constants';
 import { withExamStore } from '../hocs';
 
 /* give an extra 5 seconds where the timer holds at 00:00 before page refreshes */
@@ -47,18 +46,7 @@ const TimerServiceProvider = ({ children, attempt, pollHandler }) => {
     },
   ).join(':');
 
-  // AED 2020-02-21:
-  // If the learner is in a state where they've finished the exam
-  // and the attempt can be submitted (i.e. they are "ready_to_submit"),
-  // don't ping the proctoring app (which action could move
-  // the attempt into an error state).
   const pollExam = () => {
-    // Fixme: this condition has no effect because attempt status is always 'started'.
-    // This happens because pollExam becomes a closure
-    // and uses attempt_status value from when component was first rendered.
-    if (attempt.attempt_status === ExamStatus.READY_TO_SUBMIT) {
-      return;
-    }
     const url = attempt.exam_started_poll_url;
     const queryString = `?sourceid=in_exam&proctored=${attempt.taking_as_proctored}`;
     pollHandler(url + queryString);


### PR DESCRIPTION
This PR fixes a bug where an exam would be polled when in 'ready_to_submit' status which could move the attempt into an error state.

JIRA: [EDUCATOR-5798](https://openedx.atlassian.net/browse/EDUCATOR-5798)

should be merged first