### PR TITLE
[BD-26][EDUCATOR-5791, EDUCATOR-5767] Add handling of exam API errors and support for js workers from provider

### DIFF
--- a/src/data/index.js
+++ b/src/data/index.js
@@ -6,6 +6,7 @@ export {
   submitExam,
   expireExam,
   pollAttempt,
+  pingAttempt,
 } from './thunks';
 
 export { default as store } from './store';

--- a/src/data/messages/constants.js
+++ b/src/data/messages/constants.js
@@ -1,0 +1,25 @@
+const SUBMIT_MAP = Object.freeze({
+  promptEventName: 'endExamAttempt',
+  successEventName: 'examAttemptEnded',
+  failureEventName: 'examAttemptEndFailed',
+});
+
+const START_MAP = Object.freeze({
+  promptEventName: 'startExamAttempt',
+  successEventName: 'examAttemptStarted',
+  failureEventName: 'examAttemptStartFailed',
+});
+
+const PING_MAP = Object.freeze({
+  promptEventName: 'ping',
+  successEventName: 'echo',
+  failureEventName: 'pingFailed',
+});
+
+const actionToMessageTypesMap = Object.freeze({
+  submit: SUBMIT_MAP,
+  start: START_MAP,
+  ping: PING_MAP,
+});
+
+export default actionToMessageTypesMap;

--- a/src/data/messages/handlers.js
+++ b/src/data/messages/handlers.js
@@ -1,0 +1,44 @@
+import actionToMessageTypesMap from './constants';
+
+function createWorker(url) {
+  const blob = new Blob([`importScripts('${url}');`], { type: 'application/javascript' });
+  const blobUrl = window.URL.createObjectURL(blob);
+  return new Worker(blobUrl);
+}
+
+function workerTimeoutPromise(timeoutMilliseconds) {
+  const message = `worker failed to respond after ${timeoutMilliseconds} ms`;
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      reject(Error(message));
+    }, timeoutMilliseconds);
+  });
+}
+
+export function workerPromiseForEventNames(eventNames, workerUrl) {
+  return (timeout) => {
+    const proctoringBackendWorker = createWorker(workerUrl);
+    return new Promise((resolve, reject) => {
+      const responseHandler = (e) => {
+        if (e.data.type === eventNames.successEventName) {
+          proctoringBackendWorker.removeEventListener('message', responseHandler);
+          proctoringBackendWorker.terminate();
+          resolve();
+        } else {
+          reject(e.data.error);
+        }
+      };
+      proctoringBackendWorker.addEventListener('message', responseHandler);
+      proctoringBackendWorker.postMessage({ type: eventNames.promptEventName, timeout });
+    });
+  };
+}
+
+export function pingApplication(timeoutInSeconds, workerUrl) {
+  const TIMEOUT_BUFFER_SECONDS = 10;
+  const workerPingTimeout = timeoutInSeconds - TIMEOUT_BUFFER_SECONDS; // 10s buffer for worker to respond
+  return Promise.race([
+    workerPromiseForEventNames(actionToMessageTypesMap.ping, workerUrl)(workerPingTimeout * 1000),
+    workerTimeoutPromise(timeoutInSeconds * 1000),
+  ]);
+}

--- a/src/data/slice.js
+++ b/src/data/slice.js
@@ -8,6 +8,7 @@ export const examSlice = createSlice({
     timeIsOver: false,
     activeAttempt: null,
     exam: {},
+    apiErrorMsg: '',
   },
   reducers: {
     setIsLoading: (state, { payload }) => {
@@ -19,21 +20,21 @@ export const examSlice = createSlice({
     },
     setActiveAttempt: (state, { payload }) => {
       state.activeAttempt = payload.activeAttempt;
-      const examAttempt = state.exam.attempt;
-      if (examAttempt && examAttempt.attempt_id === payload.activeAttempt.attempt_id) {
-        state.exam.attempt = payload.activeAttempt;
-      }
+      state.apiErrorMsg = '';
     },
     expireExamAttempt: (state) => {
       state.timeIsOver = true;
     },
     getExamId: (state) => state.examId,
+    setApiError: (state, { payload }) => {
+      state.apiErrorMsg = payload.errorMsg;
+    },
   },
 });
 
 export const {
   setIsLoading, setExamState, getExamId, expireExamAttempt,
-  setActiveAttempt,
+  setActiveAttempt, setApiError,
 } = examSlice.actions;
 
 export default examSlice.reducer;

--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -18,8 +18,8 @@ import ExamAPIError from './ExamAPIError';
 const Exam = ({ isTimeLimited, children }) => {
   const state = useContext(ExamStateContext);
   const {
-    isLoading, activeAttempt, showTimer,
-    stopExam, expireExam, pollAttempt, apiErrorMsg,
+    isLoading, activeAttempt, showTimer, stopExam,
+    expireExam, pollAttempt, apiErrorMsg, pingAttempt,
   } = state;
 
   if (isLoading) {
@@ -40,6 +40,7 @@ const Exam = ({ isTimeLimited, children }) => {
           stopExamAttempt={stopExam}
           expireExamAttempt={expireExam}
           pollExamAttempt={pollAttempt}
+          pingAttempt={pingAttempt}
         />
       )}
       {apiErrorMsg && <ExamAPIError details={apiErrorMsg} />}

--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -4,6 +4,7 @@ import { Spinner } from '@edx/paragon';
 import { ExamTimerBlock } from '../timer';
 import Instructions from '../instructions';
 import ExamStateContext from '../context';
+import ExamAPIError from './ExamAPIError';
 
 /**
  * Exam component is intended to render exam instructions before and after exam.
@@ -18,7 +19,7 @@ const Exam = ({ isTimeLimited, children }) => {
   const state = useContext(ExamStateContext);
   const {
     isLoading, activeAttempt, showTimer,
-    stopExam, expireExam, pollAttempt,
+    stopExam, expireExam, pollAttempt, apiErrorMsg,
   } = state;
 
   if (isLoading) {
@@ -41,6 +42,7 @@ const Exam = ({ isTimeLimited, children }) => {
           pollExamAttempt={pollAttempt}
         />
       )}
+      {apiErrorMsg && <ExamAPIError details={apiErrorMsg} />}
       {isTimeLimited
         ? <Instructions>{sequenceContent}</Instructions>
         : sequenceContent}

--- a/src/exam/ExamAPIError.jsx
+++ b/src/exam/ExamAPIError.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Alert, Icon } from '@edx/paragon';
+import { Info } from '@edx/paragon/icons';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+
+// Fixme: Replace with store state data once exam settings are implemented
+const platformName = 'edX';
+const contactUs = 'https://courses.edx.org/support/contact_us';
+
+export default function ExamAPIError({ details }) {
+  return (
+    <Alert variant="danger">
+      <Icon src={Info} className="alert-icon" />
+      <Alert.Heading>
+        <FormattedMessage
+          id="exam.apiError.text"
+          defaultMessage={
+            'A system error has occurred with your exam. '
+              + 'Please reach out to {support_link} for assistance, '
+              + 'and return to the exam once you receive further instructions.'
+          }
+          values={{ support_link: <a href={contactUs} target="_blank" rel="noopener noreferrer">{platformName} Support</a> }}
+        />
+      </Alert.Heading>
+      <p>
+        <FormattedMessage
+          id="exam.apiError.details"
+          defaultMessage="Details"
+        />: {details}
+      </p>
+    </Alert>
+  );
+}
+
+ExamAPIError.propTypes = {
+  details: PropTypes.string.isRequired,
+};

--- a/src/timer/ExamTimerBlock.jsx
+++ b/src/timer/ExamTimerBlock.jsx
@@ -16,7 +16,7 @@ import {
  * Exam timer block component.
  */
 const ExamTimerBlock = injectIntl(({
-  attempt, stopExamAttempt, expireExamAttempt, pollExamAttempt, intl,
+  attempt, stopExamAttempt, expireExamAttempt, pollExamAttempt, intl, pingAttempt,
 }) => {
   const [isShowMore, showMore, showLess] = useToggle(false);
   const [alertVariant, setAlertVariant] = useState('info');
@@ -41,7 +41,7 @@ const ExamTimerBlock = injectIntl(({
   }, []);
 
   return (
-    <TimerProvider attempt={attempt} pollHandler={pollExamAttempt}>
+    <TimerProvider attempt={attempt} pollHandler={pollExamAttempt} pingHandler={pingAttempt}>
       <Alert variant={alertVariant}>
         <div className="d-flex justify-content-between flex-column flex-lg-row align-items-start">
           <div>

--- a/src/timer/TimerProvider.jsx
+++ b/src/timer/TimerProvider.jsx
@@ -27,10 +27,14 @@ const getFormattedRemainingTime = (timeLeft) => ({
   seconds: Math.floor(timeLeft % 60),
 });
 
-const TimerServiceProvider = ({ children, attempt, pollHandler }) => {
+const TimerServiceProvider = ({
+  children, attempt, pollHandler, pingHandler,
+}) => {
   const [timeState, setTimeState] = useState({});
   const [limitReached, setLimitReached] = useToggle(false);
   const {
+    desktop_application_js_url: workerUrl,
+    ping_interval: pingInterval,
     time_remaining_seconds: timeRemaining,
     critically_low_threshold_sec: criticalLowTime,
     low_threshold_sec: lowTime,
@@ -89,6 +93,11 @@ const TimerServiceProvider = ({ children, attempt, pollHandler }) => {
       if (timerTick % POLL_INTERVAL === 0 && secondsLeft >= 0) {
         pollExam();
       }
+
+      // if exam is proctored ping provider app also
+      if (workerUrl && timerTick % pingInterval === pingInterval / 2) {
+        pingHandler(pingInterval, workerUrl);
+      }
     }, 1000);
 
     return () => { clearInterval(interval); };
@@ -111,15 +120,19 @@ TimerServiceProvider.propTypes = {
     critically_low_threshold_sec: PropTypes.number.isRequired,
     low_threshold_sec: PropTypes.number.isRequired,
     exam_started_poll_url: PropTypes.string,
+    desktop_application_js_url: PropTypes.string,
+    ping_interval: PropTypes.number,
     taking_as_proctored: PropTypes.bool,
     attempt_status: PropTypes.string.isRequired,
   }).isRequired,
   children: PropTypes.element.isRequired,
   pollHandler: PropTypes.func,
+  pingHandler: PropTypes.func,
 };
 
 TimerServiceProvider.defaultProps = {
   pollHandler: () => {},
+  pingHandler: () => {},
 };
 
 export default withExamStore(TimerServiceProvider, mapStateToProps);


### PR DESCRIPTION
This PR allows user-friendly handling of exam API errors (previously the errors would just be printed in the console) and also adds support for js workers from proctoring providers

JIRA: [EDUCATOR-5791](https://openedx.atlassian.net/browse/EDUCATOR-5791) [EDUCATOR-5767](https://openedx.atlassian.net/browse/EDUCATOR-5767)

should be merged second