### PR TITLE
[BD-26] Fix a bug with continue button when on ready_to_submit page

### DIFF
--- a/src/instructions/proctored_exam/SubmitProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/SubmitProctoredExamInstructions.jsx
@@ -13,7 +13,7 @@ const SubmitProctoredExamInstructions = () => {
     activeAttempt,
   } = state;
   const { type: examType } = exam || {};
-  const { exam_display_name: examName } = activeAttempt;
+  const { exam_display_name: examName, can_continue: canContinue } = activeAttempt;
 
   return (
     <>
@@ -49,19 +49,20 @@ const SubmitProctoredExamInstructions = () => {
           />
         </p>
       )}
-      <Button variant="primary" onClick={submitExam}>
+      <Button variant="primary" onClick={submitExam} className="mr-2" data-testid="end-exam-button">
         <FormattedMessage
           id="exam.SubmitProctoredExamInstructions.submit"
           defaultMessage="Yes, end my proctored exam"
         />
       </Button>
-      &nbsp;
-      <Button variant="outline-primary" onClick={continueExam}>
-        <FormattedMessage
-          id="exam.SubmitProctoredExamInstructions.continue"
-          defaultMessage="No, I'd like to continue working"
-        />
-      </Button>
+      {canContinue && (
+        <Button variant="outline-primary" onClick={continueExam} data-testid="continue-exam-button">
+          <FormattedMessage
+            id="exam.SubmitProctoredExamInstructions.continue"
+            defaultMessage="No, I'd like to continue working"
+          />
+        </Button>
+      )}
     </>
   );
 };

--- a/src/instructions/timed_exam/SubmitTimedExamInstructions.jsx
+++ b/src/instructions/timed_exam/SubmitTimedExamInstructions.jsx
@@ -5,7 +5,8 @@ import ExamStateContext from '../../context';
 
 const SubmitTimedExamInstructions = () => {
   const state = useContext(ExamStateContext);
-  const { submitExam, continueExam } = state;
+  const { submitExam, continueExam, activeAttempt } = state;
+  const { can_continue: canContinue } = activeAttempt;
 
   return (
     <>
@@ -27,19 +28,20 @@ const SubmitTimedExamInstructions = () => {
           defaultMessage="After you submit your exam, your exam will be graded."
         />
       </p>
-      <Button variant="primary" onClick={submitExam}>
+      <Button variant="primary" onClick={submitExam} className="mr-2" data-testid="end-exam-button">
         <FormattedMessage
           id="exam.submitExamInstructions.submit"
           defaultMessage="Yes, submit my timed exam."
         />
       </Button>
-      &nbsp;
-      <Button variant="outline-primary" onClick={continueExam}>
-        <FormattedMessage
-          id="exam.submitExamInstructions.continue"
-          defaultMessage="No, I want to continue working."
-        />
-      </Button>
+      {canContinue && (
+        <Button variant="outline-primary" onClick={continueExam} data-testid="continue-exam-button">
+          <FormattedMessage
+            id="exam.submitExamInstructions.continue"
+            defaultMessage="No, I want to continue working."
+          />
+        </Button>
+      )}
     </>
   );
 };


### PR DESCRIPTION
Add a condition based on which continue button should be shown on ready_to_submit page, previously it was always shown

[YouTrack](https://youtrack.raccoongang.com/issue/OeX_Proctoring-234)